### PR TITLE
Copy file from spiffs to sd

### DIFF
--- a/src/MenuItemSPIFFS.cpp
+++ b/src/MenuItemSPIFFS.cpp
@@ -1,6 +1,5 @@
 #include <MenuItemSPIFFS.h>
 #include <SPIFFS.h>
-#include <M5StackUpdater.h>   // https://github.com/tobozo/M5Stack-SD-Updater/
 #include <SD.h>
 
 static SDUpdater sdUpdater;

--- a/src/MenuItemSPIFFS.cpp
+++ b/src/MenuItemSPIFFS.cpp
@@ -2,8 +2,6 @@
 #include <SPIFFS.h>
 #include <SD.h>
 
-static SDUpdater sdUpdater;
-
 MenuItemFS* MenuItemSPIFFS::newMenuItemFS(const String& title, const String& path, bool isdir) const
 {
   return new MenuItemSPIFFS(title, path, isdir);

--- a/src/MenuItemSPIFFS.cpp
+++ b/src/MenuItemSPIFFS.cpp
@@ -1,10 +1,39 @@
 #include <MenuItemSPIFFS.h>
 #include <SPIFFS.h>
+#include <M5StackUpdater.h>   // https://github.com/tobozo/M5Stack-SD-Updater/
+#include <SD.h>
+
+static SDUpdater sdUpdater;
 
 MenuItemFS* MenuItemSPIFFS::newMenuItemFS(const String& title, const String& path, bool isdir) const
 {
   return new MenuItemSPIFFS(title, path, isdir);
 }
+
+void MenuItemSPIFFS::onEnter() {
+  if (path.length()) {
+    
+    fs::FS spiffs(getFS());
+    SD.begin();
+    
+    File srcFile = spiffs.open(path);
+    File destFile = SD.open( path, FILE_WRITE );
+    
+    if( destFile ) {
+      static uint8_t buf[512];
+      size_t packets = 0;
+      while( srcFile.read( buf, 512 ) ) {
+        destFile.write(buf, 512);
+        packets++;
+      }
+      destFile.close();
+      //spiffs.remove( path );
+      ESP.restart();
+    }
+  }
+  MenuItemFS::onEnter();
+}
+
 
 fs::FS& MenuItemSPIFFS::getFS() const {
   if (0 == path.length()) SPIFFS.begin();

--- a/src/MenuItemSPIFFS.h
+++ b/src/MenuItemSPIFFS.h
@@ -15,6 +15,7 @@ public:
   MenuItemSPIFFS(const String& title, const String& path, bool isdir)
   : MenuItemFS(title, path, isdir) {};
 
+  virtual void onEnter();
 
 protected:
   virtual MenuItemFS* newMenuItemFS(const String& title, const String& path, bool isdir) const;


### PR DESCRIPTION
This is only a dummy implementation to suggest copy (or move) files from SPIFFS to SD so you don't have to remove the SD from the M5Stack.

Initial idea from https://twitter.com/robo8080/status/1093808287244402688 poke @robo8080 

do not merge ^_^